### PR TITLE
Add Travis-CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: ruby
+
+rvm:
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - 2.2.0
+  - jruby-19mode
+  - jruby-head
+  - rbx-19mode
+  - rbx-2

--- a/directory_monitor.gemspec
+++ b/directory_monitor.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'trollop', '~> 2.0'
 
   spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "minitest"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "simplecov", "~> 0.9"
 end

--- a/test/directory_monitor_tc.rb
+++ b/test/directory_monitor_tc.rb
@@ -36,7 +36,7 @@ class DirectoryMonitor::DirectoryMonitor
   end
 end
 
-class DirectoryMonitor_Base_TestCase < MiniTest::Unit::TestCase
+class DirectoryMonitor_Base_TestCase < Minitest::Test
 
   private
 

--- a/test/options_tc.rb
+++ b/test/options_tc.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 require "directory_monitor/options"
 
-class Optionse_TestCase < MiniTest::Unit::TestCase
+class Optionse_TestCase < Minitest::Test
 
   private
 

--- a/test/watch_tc.rb
+++ b/test/watch_tc.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class Watch_Commandline_TestCase < MiniTest::Unit::TestCase
+class Watch_Commandline_TestCase < Minitest::Test
 
   # We need a set of tests that run "out of process" in a way that let's us
   # both verify that the watch script executable is sort of working, as well


### PR DESCRIPTION
You'll need to create a travis-ci.org account and enable travis for this repo, but this config should be sufficient to make travis run the test suite and report any errors after each batch of commits that is pushed. Once that's setup you can add a badge to the README too.

You may not be interested in rubinius and jruby, but figured might as well include them and help those ecosystems gather wider support. Surprisingly, it's not the other VMs that have an issue, but merry Xmas, [Ruby 2.2.0 doesn't like the latest build](https://travis-ci.org/tdg5/directory_monitor/builds/45149490), so that's something to look into.

UPDATE:
Fixed the Ruby 2.2.0 build.

Turns out [Ruby 2.2 removes minitest from the ruby build](https://www.ruby-lang.org/en/news/2014/12/25/ruby-2-2-0-released/). It's still included w/ the source, but must be compiled separately from the Ruby build. So, the fix is to add minitest to the gemspec's development dependencies and install it in its gemified form. The version of minitest that I pulled down was issuing a bunch of warnings so I fixed those as well.

[Successful Travis build](https://travis-ci.org/tdg5/directory_monitor/builds/45158750)
